### PR TITLE
added authorize annotation to endpoints for post controller

### DIFF
--- a/Controllers/PostController.cs
+++ b/Controllers/PostController.cs
@@ -24,6 +24,7 @@ public class PostController : ControllerBase
     }
 
     [HttpGet]
+    [Authorize(Roles = "Admin")]
     public IActionResult GetPosts()
     {
         return Ok(
@@ -36,6 +37,7 @@ public class PostController : ControllerBase
 
     [HttpGet]
     [Route("public")]
+    [Authorize]
     public IActionResult GetPublicPosts()
     {
         return Ok(


### PR DESCRIPTION
This adds `Authorize` annotation to each endpoint in the post controller. The `GetPosts` endpoint requires Admin role.