### PR TITLE
added creation date property

### DIFF
--- a/Models/Post.cs
+++ b/Models/Post.cs
@@ -31,5 +31,8 @@ public class Post
     public bool IsApproved { get; set; }
 
     [Required]
+    public DateTime CreationDate { get; set; }
+
+    [Required]
     public DateTime? Publication { get; set; }
 }


### PR DESCRIPTION
Added property `CreationDate` to the post model.

How to test:
run `dotnet ef migrations add CreationDate`
then, run `dotnet ef database update`

If this doesn't work, check that your terminal is in the correct directory and that you are not currently running the API.
If it still doesn't work, you may ask about it or nuke the database and try again.