### PR TITLE
removed admin authorization from get tag endpoints

### DIFF
--- a/Controllers/TagController.cs
+++ b/Controllers/TagController.cs
@@ -22,7 +22,7 @@ public class TagController : ControllerBase
 
 
     [HttpGet]
-    [Authorize(Roles = "Admin")]
+    [Authorize]
     public IActionResult GetAllTags()
     {
         return Ok(_db.Tags.Select(c => new TagDTO
@@ -33,7 +33,7 @@ public class TagController : ControllerBase
     }
 
     [HttpGet("{Id}")]
-    [Authorize(Roles = "Admin")]
+    [Authorize]
       public IActionResult GetTagById(int Id)
     {
         return Ok(_db.Tags.Select(c => new TagDTO


### PR DESCRIPTION
The get tag endpoints need not require admin role, as authors need to see them to apply them to their posts.

I removed the parameters for admin role from the get all tags endpoint and the get tag by id endpoint