### PR TITLE
client cannot edit post if they do not own it

### DIFF
--- a/Controllers/PostController.cs
+++ b/Controllers/PostController.cs
@@ -117,7 +117,12 @@ public class PostController : ControllerBase
     [Authorize]
     public IActionResult EditPost(PutPostByMeDTO puttedPost, int id)
     {
-        Post existingPost = _dbContext.Posts.SingleOrDefault(p => p.Id == id);
+        string identityUserId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        UserProfile profile = _dbContext.UserProfiles.SingleOrDefault(up =>
+            up.IdentityUserId == identityUserId
+        );
+
+        Post existingPost = _dbContext.Posts.SingleOrDefault(p => p.Id == id && p.AuthorId == profile.Id);
 
         if (existingPost != null)
         {
@@ -160,7 +165,7 @@ public class PostController : ControllerBase
             return NoContent();
         }
 
-        return BadRequest("There is no post with given id.");
+        return BadRequest("There is no post with given id or you are not the owner of this post.");
     }
 
     [HttpDelete]


### PR DESCRIPTION
Made it such that the edit post endpoint checks if you are the user that created the post. If you are not the author, the endpoint returns bad request.

To test:
I tested it by temporarily removing the `UserIsAuthor` component wrapping the edit post component in `ApplicationViews.jsx` (lines 142 and 145), allowing me to access the edit form for a post without being its author. When you edit and submit, you should get bad request returned.