### PR TITLE
Ft/change user type

### DIFF
--- a/client/src/components/userprofiles/UserProfilesList.jsx
+++ b/client/src/components/userprofiles/UserProfilesList.jsx
@@ -51,8 +51,8 @@ export default function UserProfileList()
           <Link to={`/userprofiles/${p.id}`}>Details</Link>
           {
             p.roles.includes("Admin")
-              ? <button onClick={() => demoteClicked(p.id)}>Demote</button>
-              : <button onClick={() => promoteClicked(p.id)}>Promote</button>
+              ? <button onClick={() => demoteClicked(p.identityUserId)}>Demote</button>
+              : <button onClick={() => promoteClicked(p.identityUserId)}>Promote</button>
           }
         </p>
       ))}

--- a/client/src/components/userprofiles/UserProfilesList.jsx
+++ b/client/src/components/userprofiles/UserProfilesList.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { getProfiles } from "../../managers/userProfileManager";
+import { demoteProfile, getProfiles, promoteProfile } from "../../managers/userProfileManager";
 import { Link } from "react-router-dom";
 
 export default function UserProfileList()
@@ -32,14 +32,14 @@ export default function UserProfileList()
     getUserProfiles();
   }, []);
 
-  const promoteUser = (userId) =>
+  const promoteClicked = (userId) =>
   {
-    
+    promoteProfile(userId)
   }
 
-  const demoteUser = (userId) =>
+  const demoteClicked = (userId) =>
   {
-
+    demoteProfile(userId)
   }
 
   return (
@@ -51,8 +51,8 @@ export default function UserProfileList()
           <Link to={`/userprofiles/${p.id}`}>Details</Link>
           {
             p.roles.includes("Admin")
-            ? <button>Demote</button>
-            : <button>Promote</button>
+              ? <button onClick={() => demoteClicked(p.id)}>Demote</button>
+              : <button onClick={() => promoteClicked(p.id)}>Promote</button>
           }
         </p>
       ))}

--- a/client/src/components/userprofiles/UserProfilesList.jsx
+++ b/client/src/components/userprofiles/UserProfilesList.jsx
@@ -34,12 +34,12 @@ export default function UserProfileList()
 
   const promoteClicked = (userId) =>
   {
-    promoteProfile(userId)
+    promoteProfile(userId).then(getUserProfiles)
   }
 
   const demoteClicked = (userId) =>
   {
-    demoteProfile(userId)
+    demoteProfile(userId).then(getUserProfiles)
   }
 
   return (

--- a/client/src/components/userprofiles/UserProfilesList.jsx
+++ b/client/src/components/userprofiles/UserProfilesList.jsx
@@ -31,6 +31,17 @@ export default function UserProfileList()
   {
     getUserProfiles();
   }, []);
+
+  const promoteUser = (userId) =>
+  {
+    
+  }
+
+  const demoteUser = (userId) =>
+  {
+
+  }
+
   return (
     <>
       <p>User Profile List</p>
@@ -38,6 +49,11 @@ export default function UserProfileList()
         <p key={p.id}>
           {p.firstName} {p.lastName} {p.userName} {p.roles.includes("Admin") ? "admin" : "author"}
           <Link to={`/userprofiles/${p.id}`}>Details</Link>
+          {
+            p.roles.includes("Admin")
+            ? <button>Demote</button>
+            : <button>Promote</button>
+          }
         </p>
       ))}
     </>

--- a/client/src/managers/userProfileManager.js
+++ b/client/src/managers/userProfileManager.js
@@ -1,9 +1,21 @@
 const _apiUrl = "/api/userprofile";
 
-export const getProfiles = () => {
+export const getProfiles = () =>
+{
   return fetch(_apiUrl + "/withroles").then((res) => res.json());
 };
 
-export const getProfile = (id) => {
+export const getProfile = (id) =>
+{
   return fetch(_apiUrl + `/${id}`).then((res) => res.json());
 };
+
+export const promoteProfile = (id) =>
+{
+  return fetch(_apiUrl + `/promote/${id}`)
+}
+
+export const demoteProfile = (id) =>
+{
+  return fetch(_apiUrl + `/demote/${id}`)
+}

--- a/client/src/managers/userProfileManager.js
+++ b/client/src/managers/userProfileManager.js
@@ -12,10 +12,10 @@ export const getProfile = (id) =>
 
 export const promoteProfile = (id) =>
 {
-  return fetch(_apiUrl + `/promote/${id}`)
+  return fetch(_apiUrl + `/promote/${id}`, { method: "POST" })
 }
 
 export const demoteProfile = (id) =>
 {
-  return fetch(_apiUrl + `/demote/${id}`)
+  return fetch(_apiUrl + `/demote/${id}`, { method: "POST" })
 }


### PR DESCRIPTION
Admins can now promote authors to admins and demote admins to authors.

Changes:
1. Added manager functions to interact with promote and demote endpoints
2. Added buttons for promoting and demoting and functions for handling their presses

To test:
1. Pull and checkout, restart API
2. Log in as admin, navigate to user profile list page
3. Observe promote and demote buttons
4. Click a promote button, ensure a `AspNetUserRole` appears in the database and ensure promote button becomes demote button
5. Click a demote button, ensure a `AspNetUserRole` is removed from the database and the demote button becomes a promote button

closes #20 