### PR TITLE
Ft/reactivate user

### DIFF
--- a/Controllers/UserProfileController.cs
+++ b/Controllers/UserProfileController.cs
@@ -131,5 +131,27 @@ public class UserProfileController : ControllerBase
         return Ok();
     }
 
+    [HttpGet("deactivated")]
+    [Authorize(Roles = "Admin")]
+    public IActionResult GetDeactivated()
+    {
+        return Ok(_dbContext.UserProfiles
+        .Include(up => up.IdentityUser).Where(up => up.IsDeactivated == true)
+        .Select(up => new UserProfile
+        {
+            Id = up.Id,
+            FirstName = up.FirstName,
+            LastName = up.LastName,
+            Email = up.IdentityUser.Email,
+            UserName = up.IdentityUser.UserName,
+            IdentityUserId = up.IdentityUserId,
+            IsDeactivated = up.IsDeactivated,
+            Roles = _dbContext.UserRoles
+            .Where(ur => ur.UserId == up.IdentityUserId)
+            .Select(ur => _dbContext.Roles.SingleOrDefault(r => r.Id == ur.RoleId).Name)
+            .ToList()
+        }));
+    }
+
 
 }

--- a/Controllers/UserProfileController.cs
+++ b/Controllers/UserProfileController.cs
@@ -109,7 +109,23 @@ public class UserProfileController : ControllerBase
             return BadRequest("This user does not exist");
         }
 
-       userToDeactivate.IsDeactivated = true;
+        userToDeactivate.IsDeactivated = true;
+
+        _dbContext.SaveChanges();
+        return Ok();
+    }
+
+    [HttpPut("reactivate/{id}")]
+    [Authorize(Roles = "Admin")]
+    public IActionResult Reactivate(int id)
+    {
+        UserProfile userToReactivate = _dbContext.UserProfiles.FirstOrDefault(u => u.Id == id);
+        if (userToReactivate == null)
+        {
+            return BadRequest("This user does not exist");
+        }
+
+        userToReactivate.IsDeactivated = false;
 
         _dbContext.SaveChanges();
         return Ok();

--- a/Controllers/UserProfileController.cs
+++ b/Controllers/UserProfileController.cs
@@ -131,4 +131,5 @@ public class UserProfileController : ControllerBase
         return Ok();
     }
 
+
 }

--- a/client/src/components/userprofiles/UserProfilesList.jsx
+++ b/client/src/components/userprofiles/UserProfilesList.jsx
@@ -7,20 +7,7 @@ import { Link } from "react-router-dom";
 export default function UserProfileList() {
   const [userprofiles, setUserProfiles] = useState([]);
   const [filteredUsers, setFilteredUsers] = useState(false);
-
-  const handleFilterChange = (event) => {
-    setFilteredUsers(event.target.checked);
-   
-  };
-
-  useEffect(() => {
-    if (filteredUsers === true) {
-      setUserProfiles(userprofiles.filter((p) => p.isDeactivated === true));
-    }
-    else {
-      setFilteredUsers(userprofiles);
-    }
-  }, [filteredUsers]);
+  const [deactivatedProfiles, setDeactivatedProfiles] = useState([]);
 
   const getUserProfiles = () => {
     getProfiles().then(
@@ -38,9 +25,27 @@ export default function UserProfileList() {
       }
     );
   };
+
+  const getDeactivatedUsers = () => {
+    getDeactivatedProfiles().then(
+      (gottenProfiles) => {
+        gottenProfiles = gottenProfiles.sort(function (a, b) {
+          if (a.userName.toLowerCase() < b.userName.toLowerCase()) {
+            return -1;
+          }
+          if (a.userName.toLowerCase() > b.userName.toLowerCase()) {
+            return 1;
+          }
+          return 0;
+        });
+        setDeactivatedProfiles(gottenProfiles)
+      }
+    );
+  }
+
   useEffect(() => {
     getUserProfiles();
-   
+    getDeactivatedUsers();
   }, []);
 
   const handleDeactivate = (event) => {
@@ -54,6 +59,18 @@ export default function UserProfileList() {
       reactivateUser(event.target.value).then(() => getUserProfiles());
     }
   };
+
+  const handleFilterChange = (event) => {
+    
+    if (event.target.checked) {
+      setUserProfiles(deactivatedProfiles);
+    }
+    else {
+      getUserProfiles();
+    }
+  };
+
+
   return (
     <>
       <h3>User Profile List</h3>

--- a/client/src/components/userprofiles/UserProfilesList.jsx
+++ b/client/src/components/userprofiles/UserProfilesList.jsx
@@ -50,13 +50,19 @@ export default function UserProfileList() {
 
   const handleDeactivate = (event) => {
     if (window.confirm(`Confirm deactivation of: ${event.target.name}`)) {
-      deactivateUser(event.target.value).then(() => getUserProfiles());
+      deactivateUser(event.target.value).then(() => {
+        getUserProfiles();
+        getDeactivatedUsers();
+      });
     }
   };
 
   const handleReactivate = (event) => {
     if (window.confirm(`Confirm Reactivation of: ${event.target.name}`)) {
-      reactivateUser(event.target.value).then(() => getUserProfiles());
+      reactivateUser(event.target.value).then(() => {
+        getUserProfiles();
+        getDeactivatedUsers();
+      });
     }
   };
 

--- a/client/src/components/userprofiles/UserProfilesList.jsx
+++ b/client/src/components/userprofiles/UserProfilesList.jsx
@@ -1,13 +1,26 @@
 import { useEffect, useState } from "react";
-import { deactivateUser, getProfiles, reactivateUser } from "../../managers/userProfileManager";
+import { deactivateUser, getDeactivatedProfiles, getProfiles, reactivateUser } from "../../managers/userProfileManager";
 
 import { Link } from "react-router-dom";
 
 
 export default function UserProfileList() {
   const [userprofiles, setUserProfiles] = useState([]);
-  const[deactivatedUsers, setDeactivatedUsers] = useState([]);
+  const [filteredUsers, setFilteredUsers] = useState(false);
 
+  const handleFilterChange = (event) => {
+    setFilteredUsers(event.target.checked);
+   
+  };
+
+  useEffect(() => {
+    if (filteredUsers === true) {
+      setUserProfiles(userprofiles.filter((p) => p.isDeactivated === true));
+    }
+    else {
+      setFilteredUsers(userprofiles);
+    }
+  }, [filteredUsers]);
 
   const getUserProfiles = () => {
     getProfiles().then(
@@ -27,6 +40,7 @@ export default function UserProfileList() {
   };
   useEffect(() => {
     getUserProfiles();
+   
   }, []);
 
   const handleDeactivate = (event) => {
@@ -42,7 +56,15 @@ export default function UserProfileList() {
   };
   return (
     <>
-      <p>User Profile List</p>
+      <h3>User Profile List</h3>
+      <label>
+        <input
+          type="checkbox"
+          defaultChecked={false}
+          onChange={handleFilterChange}
+        />
+        View Deactivated Only
+      </label>
       {userprofiles.map((p) => (
 
         <div key={p.id}>

--- a/client/src/components/userprofiles/UserProfilesList.jsx
+++ b/client/src/components/userprofiles/UserProfilesList.jsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from "react";
-import { deactivateUser, getProfiles } from "../../managers/userProfileManager";
+import { deactivateUser, getProfiles, reactivateUser } from "../../managers/userProfileManager";
 
 import { Link } from "react-router-dom";
 
 
 export default function UserProfileList() {
   const [userprofiles, setUserProfiles] = useState([]);
+  const[deactivatedUsers, setDeactivatedUsers] = useState([]);
 
 
   const getUserProfiles = () => {
@@ -33,6 +34,12 @@ export default function UserProfileList() {
       deactivateUser(event.target.value).then(() => getUserProfiles());
     }
   };
+
+  const handleReactivate = (event) => {
+    if (window.confirm(`Confirm Reactivation of: ${event.target.name}`)) {
+      reactivateUser(event.target.value).then(() => getUserProfiles());
+    }
+  };
   return (
     <>
       <p>User Profile List</p>
@@ -48,6 +55,11 @@ export default function UserProfileList() {
           {!p.isDeactivated && !p.roles.includes("Admin") && (
             <button name={p.userName} value={p.id} onClick={handleDeactivate}>
               Deactivate
+            </button>
+          )}
+          {p.isDeactivated && !p.roles.includes("Admin") && (
+            <button name={p.userName} value={p.id} onClick={handleReactivate}>
+              Reactivate
             </button>
           )}
 

--- a/client/src/managers/userProfileManager.js
+++ b/client/src/managers/userProfileManager.js
@@ -18,3 +18,13 @@ export const deactivateUser = (userId) =>
             body: JSON.stringify(userId)
         })
 };
+
+export const reactivateUser = (userId) =>
+{
+    return fetch(_apiUrl + `/${userId}`,
+        {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(userId)
+        })
+};

--- a/client/src/managers/userProfileManager.js
+++ b/client/src/managers/userProfileManager.js
@@ -21,7 +21,7 @@ export const deactivateUser = (userId) =>
 
 export const reactivateUser = (userId) =>
 {
-    return fetch(_apiUrl + `/${userId}`,
+    return fetch(_apiUrl + `/reactivate/${userId}`,
         {
             method: "PUT",
             headers: { "Content-Type": "application/json" },

--- a/client/src/managers/userProfileManager.js
+++ b/client/src/managers/userProfileManager.js
@@ -28,3 +28,8 @@ export const reactivateUser = (userId) =>
             body: JSON.stringify(userId)
         })
 };
+
+export const getDeactivatedProfiles = () => {
+  return fetch(_apiUrl + "/deactivated").then((res) => res.json());
+};
+


### PR DESCRIPTION
admins are able to reactivate a non admin user that they have deactivated
admins are able to filter the user profiles by deactivation status on the user profile list page

files changed: 
userprofilemanager.js
userprofilecontroller.cs
userprofilelist.jsx

to test:
log in as an admin and navigate to the user profile list
Try reactivating a user that has been deactivated. The button next to that user should change accordingly.
Try selecting the checkbox to view only deactivated users. Make sure you only see non admin deactivated user profiles when the box is selected. 

closes #21 