### PR TITLE
preventing the loss of admins

### DIFF
--- a/Controllers/UserProfileController.cs
+++ b/Controllers/UserProfileController.cs
@@ -103,13 +103,32 @@ public class UserProfileController : ControllerBase
     [Authorize(Roles = "Admin")]
     public IActionResult Deactivate(int id)
     {
-        UserProfile userToDeactivate = _dbContext.UserProfiles.FirstOrDefault(u => u.Id == id);
+        UserProfile userToDeactivate = _dbContext
+            .UserProfiles.Include(up => up.IdentityUser)
+            .SingleOrDefault(up => up.Id == id);
+
         if (userToDeactivate == null)
         {
             return BadRequest("This user does not exist");
         }
 
-       userToDeactivate.IsDeactivated = true;
+        IdentityRole adminRole = _dbContext.Roles.SingleOrDefault(r => r.Name == "Admin");
+        bool isUserAdmin = _dbContext.UserRoles
+        .Any(ur => ur.UserId == userToDeactivate.IdentityUserId && ur.RoleId == adminRole.Id);
+        
+        if (isUserAdmin)
+        {
+            int activeAdminCount = _dbContext.UserRoles
+                .Count(ur => ur.RoleId == adminRole.Id && !_dbContext.UserProfiles
+                .Any(up => up.IdentityUserId == ur.UserId && up.IsDeactivated));
+
+            if (activeAdminCount <= 1)
+            {
+                return BadRequest("You cannot deactivate the last remaining admin. Please assign another admin before proceeding.");
+            }
+        }
+
+        userToDeactivate.IsDeactivated = true;
 
         _dbContext.SaveChanges();
         return Ok();

--- a/client/src/components/userprofiles/UserProfilesList.jsx
+++ b/client/src/components/userprofiles/UserProfilesList.jsx
@@ -30,9 +30,17 @@ export default function UserProfileList() {
 
   const handleDeactivate = (event) => {
     if (window.confirm(`Confirm deactivation of: ${event.target.name}`)) {
-      deactivateUser(event.target.value).then(() => getUserProfiles());
+      deactivateUser(event.target.value)
+        .then(() => getUserProfiles())
+        .catch(error => {
+          if (error) {
+            window.alert(`Error: ${error}`);
+          } 
+        });
     }
   };
+
+
   return (
     <>
       <p>User Profile List</p>
@@ -45,7 +53,7 @@ export default function UserProfileList() {
 
           </p>
 
-          {!p.isDeactivated && !p.roles.includes("Admin") && (
+          {!p.isDeactivated && (
             <button name={p.userName} value={p.id} onClick={handleDeactivate}>
               Deactivate
             </button>

--- a/client/src/managers/userProfileManager.js
+++ b/client/src/managers/userProfileManager.js
@@ -9,12 +9,16 @@ export const getProfile = (id) => {
 };
 
 
-export const deactivateUser = (userId) =>
-{
-    return fetch(_apiUrl + `/${userId}`,
-        {
-            method: "PUT",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(userId)
-        })
+export const deactivateUser = (userId) => {
+  return fetch(_apiUrl + `/${userId}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ id: userId })
+  }).then(response => {
+    if (!response.ok) {
+      return response.text().then(text => {
+        return Promise.reject(text);
+      });
+    }   
+  });
 };


### PR DESCRIPTION
Admins can not deactivate themselves if they are the final activated admin user

files changed:
UserProfileController.cs
UserProfileList.jsx
userManager.js

To Test:
Log in as an admin
navigate to user profiles
start deactivating admins until you are the last one
try to deactivate yourself
you should see a pop up window telling you that you can not do this, and your deactivate button should still be rendered.

Let me know if there are any redundancies you see in the endpoint for deactivating a user. I relied heavily on chatGPT for this one. 

closes #19 