### PR TITLE
admins can unapprove posts 

### DIFF
--- a/Controllers/PostController.cs
+++ b/Controllers/PostController.cs
@@ -196,4 +196,23 @@ public class PostController : ControllerBase
 
         return NoContent();
     }
+
+
+    [HttpPut]
+    [Route("unapprove/{id}")]
+    [Authorize(Roles = "Admin")]
+    public IActionResult ApprovePost(int id)
+    {
+        Post postToUnapprove = _dbContext.Posts.SingleOrDefault(p => p.Id == id);
+
+        if (postToUnapprove != null)
+        {
+            postToUnapprove.IsApproved = false;   
+            _dbContext.SaveChanges();
+
+            return NoContent();
+        }
+
+        return BadRequest("There is no post with given id.");
+    }
 }

--- a/client/src/components/PostList.jsx
+++ b/client/src/components/PostList.jsx
@@ -74,12 +74,14 @@ const PostList = () => {
 
   const handleUnapproveClick = (event) => {
     unapprovePost(event.target.value)
-    getPublicPosts().then((posts) => {
-      setPosts(
-        posts.sort((a, b) => new Date(b.publication) - new Date(a.publication))
-      );
-    });
-  }
+      .then(() => getPublicPosts())
+      .then((posts) => {
+        setPosts(
+          posts.sort((a, b) => new Date(b.publication) - new Date(a.publication))
+        );
+      });
+  };
+
 
   return (
     <main>
@@ -123,8 +125,8 @@ const PostList = () => {
             <article key={"p" + p.id} className="PostList-post-border">
               {(user.roles.includes("Admin")) && (
                 <button
-                value = {p.id}
-                onClick={handleUnapproveClick}
+                  value={p.id}
+                  onClick={handleUnapproveClick}
                 >
                   Unapprove
                 </button>

--- a/client/src/components/PostList.jsx
+++ b/client/src/components/PostList.jsx
@@ -1,5 +1,5 @@
 import { Fragment, useContext, useEffect, useState } from "react";
-import { getPublicPosts } from "../managers/postManager";
+import { getPublicPosts, unapprovePost } from "../managers/postManager";
 import { Link } from "react-router-dom";
 import { UserContext } from "../App";
 import "./PostView.css";
@@ -43,6 +43,8 @@ const PostList = () => {
             filterSettings.Tag == 0)
       )
     );
+
+
     // if (filterSettings.Category == 0 && filterSettings.Tag == 0) {
     //   setFilteredPosts(posts);
     // } else {
@@ -69,6 +71,15 @@ const PostList = () => {
     //   }
     // }
   }, [filterSettings, posts]);
+
+  const handleUnapproveClick = (event) => {
+    unapprovePost(event.target.value)
+    getPublicPosts().then((posts) => {
+      setPosts(
+        posts.sort((a, b) => new Date(b.publication) - new Date(a.publication))
+      );
+    });
+  }
 
   return (
     <main>
@@ -110,6 +121,14 @@ const PostList = () => {
         <section className="PostList-section-posts">
           {filteredPosts.map((p) => (
             <article key={"p" + p.id} className="PostList-post-border">
+              {(user.roles.includes("Admin")) && (
+                <button
+                value = {p.id}
+                onClick={handleUnapproveClick}
+                >
+                  Unapprove
+                </button>
+              )}
               <header className="PostList-post-header">
                 {p.publication}{" "}
                 {p.authorId == user.id && (

--- a/client/src/managers/postManager.js
+++ b/client/src/managers/postManager.js
@@ -38,3 +38,13 @@ export const deletePost = (id) =>
     return fetch(`/api/post/${id}`,
         { method: "DELETE" })
 }
+
+export const unapprovePost = (id) =>
+{
+    return fetch(`/api/post/unapprove/${id}`,
+        {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(id)
+        })
+}


### PR DESCRIPTION
Admins are able to see a button on the post list view to un-approve any post

Files Changed:
PostController.cs
postManager.js
PostList.jsx

To test:
log in as an admin and navigate to the post list view
click on the button at the top of a post to un-approve it
the post should disappear from the list and the post in PgAdmin should have a status of false for IsApproved.

log in as an author and make sure you can't see the button to un-approve a post.

if you do a lot of testing and want to reset PGAdmin here is the query to reset all the posts to approved again:
UPDATE "Posts"
SET "IsApproved" = true;


closes #6 