### PR TITLE
Requires 2 Admins to depromote an admin

### DIFF
--- a/Controllers/AdminController.cs
+++ b/Controllers/AdminController.cs
@@ -1,0 +1,61 @@
+
+
+
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Tabloid.Data;
+using Tabloid.Models;
+using Tabloid.Models.DTOs;
+
+[ApiController]
+[Route("/api/[controller]")]
+public class AdminController : ControllerBase
+{
+
+    private TabloidDbContext _db;
+
+    public AdminController(TabloidDbContext context)
+    {
+        _db = context;
+    }
+
+    [HttpGet]
+    [Authorize(Roles = "Admin")]
+    public IActionResult GetAllDemotes()
+    {
+        return Ok(_db.DemoteAdmins.Select(dA => new DemoteAdminDTO
+        {
+            Id = dA.Id,
+            AdminApprovalId = dA.AdminApprovalId,
+            AdminToDemoteId = dA.AdminToDemoteId
+        }));
+    }
+
+    [HttpPost]
+    [Authorize(Roles = "Admin")]
+    public IActionResult AddNewDemote(DemoteAdminDTO newDemote)
+    {
+        _db.DemoteAdmins.Add(new DemoteAdmin {
+            AdminToDemoteId = newDemote.AdminToDemoteId,
+            AdminApprovalId = newDemote.AdminApprovalId
+        });
+
+        _db.SaveChanges();
+
+        return Ok();
+    }
+
+    [HttpDelete("{Id}")]
+    [Authorize(Roles = "Admin")]
+    public IActionResult DeleteDemote(int Id)
+    {
+
+        DemoteAdmin AdminToDelete = _db.DemoteAdmins.FirstOrDefault(da => da.Id == Id);
+
+        _db.DemoteAdmins.Remove(AdminToDelete);
+        _db.SaveChanges();
+        return Ok();
+    }
+
+}

--- a/Models/DTOs/DemoteAdminDTO.cs
+++ b/Models/DTOs/DemoteAdminDTO.cs
@@ -1,14 +1,11 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
-namespace Tabloid.Models;
+namespace Tabloid.Models.DTOs;
 
-public class DemoteAdmin
+public class DemoteAdminDTO
 {
-    [Required]
     public int Id { get; set; }
-    [Required]
     public string AdminApprovalId { get; set; }
-    [Required]
     public string AdminToDemoteId { get; set; }
 }

--- a/TabloidDbContext.cs
+++ b/TabloidDbContext.cs
@@ -320,15 +320,5 @@ public class TabloidDbContext : IdentityDbContext<IdentityUser>
                 }
             );
 
-        modelBuilder
-            .Entity<DemoteAdmin>()
-            .HasData(
-                new DemoteAdmin
-                {
-                    Id = 1,
-                    AdminApprovalId = 1,
-                    AdminToDemoteId = 2
-                }
-            );
     }
 }

--- a/client/src/components/ApplicationViews.jsx
+++ b/client/src/components/ApplicationViews.jsx
@@ -21,8 +21,7 @@ import UserIsProfile from "./userprofiles/UserIsProfile";
 import { EditCommentForm } from "./EditCommentForm";
 import UnapprovedPosts from "./UnapprovedPosts";
 
-export default function ApplicationViews({ loggedInUser, setLoggedInUser })
-{
+export default function ApplicationViews({ loggedInUser, setLoggedInUser }) {
   return (
     <Routes>
       <Route path="/">
@@ -55,14 +54,14 @@ export default function ApplicationViews({ loggedInUser, setLoggedInUser })
             index
             element={
               <AuthorizedRoute loggedInUser={loggedInUser} roles={["Admin"]}>
-                <UserProfileList />
+                <UserProfileList loggedInUser={loggedInUser} />
               </AuthorizedRoute>
             }
           />
           <Route
             path=":id"
             element={
-              <AuthorizedRoute loggedInUser={loggedInUser} >
+              <AuthorizedRoute loggedInUser={loggedInUser}>
                 <UserProfileDetails />
               </AuthorizedRoute>
             }
@@ -167,13 +166,13 @@ export default function ApplicationViews({ loggedInUser, setLoggedInUser })
             />
           </Route>
           <Route
-          path="unapproved"
-          element={
-            <AuthorizedRoute loggedInUser={loggedInUser} roles={["Admin"]}>
-              <UnapprovedPosts/>
-            </AuthorizedRoute>
-          }
-        />
+            path="unapproved"
+            element={
+              <AuthorizedRoute loggedInUser={loggedInUser} roles={["Admin"]}>
+                <UnapprovedPosts />
+              </AuthorizedRoute>
+            }
+          />
         </Route>
       </Route>
       <Route path="*" element={<p>Whoops, nothing here...</p>} />

--- a/client/src/components/userprofiles/UserProfilesList.jsx
+++ b/client/src/components/userprofiles/UserProfilesList.jsx
@@ -1,118 +1,120 @@
 import { useEffect, useState } from "react";
-import { demoteProfile, getProfiles, promoteProfile, deactivateUser, getDeactivatedProfiles, reactivateUser } from "../../managers/userProfileManager";
+import {
+  demoteProfile,
+  getProfiles,
+  promoteProfile,
+  deactivateUser,
+  getDeactivatedProfiles,
+  reactivateUser,
+} from "../../managers/userProfileManager";
 import { Link } from "react-router-dom";
+import {
+  deleteDemote,
+  getAllDemotes,
+  postNewDemote,
+} from "../../managers/admin";
 
-
-export default function UserProfileList()
-{
+export default function UserProfileList({ loggedInUser }) {
+  const [allDemotes, setAllDemotes] = useState([]);
   const [userprofiles, setUserProfiles] = useState([]);
   const [filteredUsers, setFilteredUsers] = useState(false);
   const [deactivatedProfiles, setDeactivatedProfiles] = useState([]);
 
-  const getUserProfiles = () =>
-  {
-    getProfiles().then(
-      (gottenProfiles) =>
-      {
-        gottenProfiles = gottenProfiles.sort(function (a, b)
-        {
-          if(a.userName.toLowerCase() < b.userName.toLowerCase())
-          {
-            return -1;
-          }
-          if(a.userName.toLowerCase() > b.userName.toLowerCase())
-          {
-            return 1;
-          }
-          return 0;
-        });
-        setUserProfiles(gottenProfiles)
-      }
-    );
+  const getUserProfiles = () => {
+    getProfiles().then((gottenProfiles) => {
+      gottenProfiles = gottenProfiles.sort(function (a, b) {
+        if (a.userName.toLowerCase() < b.userName.toLowerCase()) {
+          return -1;
+        }
+        if (a.userName.toLowerCase() > b.userName.toLowerCase()) {
+          return 1;
+        }
+        return 0;
+      });
+      setUserProfiles(gottenProfiles);
+    });
   };
 
-  const getDeactivatedUsers = () =>
-  {
-    getDeactivatedProfiles().then(
-      (gottenProfiles) =>
-      {
-        gottenProfiles = gottenProfiles.sort(function (a, b)
-        {
-          if(a.userName.toLowerCase() < b.userName.toLowerCase())
-          {
-            return -1;
-          }
-          if(a.userName.toLowerCase() > b.userName.toLowerCase())
-          {
-            return 1;
-          }
-          return 0;
-        });
-        setDeactivatedProfiles(gottenProfiles)
-      }
-    );
-  }
+  const getDeactivatedUsers = () => {
+    getDeactivatedProfiles().then((gottenProfiles) => {
+      gottenProfiles = gottenProfiles.sort(function (a, b) {
+        if (a.userName.toLowerCase() < b.userName.toLowerCase()) {
+          return -1;
+        }
+        if (a.userName.toLowerCase() > b.userName.toLowerCase()) {
+          return 1;
+        }
+        return 0;
+      });
+      setDeactivatedProfiles(gottenProfiles);
+    });
+  };
 
-  useEffect(() =>
-  {
+  useEffect(() => {
     getUserProfiles();
     getDeactivatedUsers();
   }, []);
 
-  const promoteClicked = (userId) =>
-  {
-    promoteProfile(userId).then(getUserProfiles)
-  }
+  useEffect(() => {
+    getAllDemotes().then(setAllDemotes);
+  }, []);
 
-  const demoteClicked = (userId) =>
-  {
-    demoteProfile(userId).then(getUserProfiles)
-  }
+  const promoteClicked = (userId) => {
+    promoteProfile(userId).then(getUserProfiles);
+  };
 
-  const handleDeactivate = (event) =>
-  {
-    if(window.confirm(`Confirm deactivation of: ${event.target.name}`))
-    {
+  const demoteClicked = (userId) => {
+    const demoteObject = allDemotes.find(
+      (dObj) => dObj.adminToDemoteId == userId
+    );
+    if (demoteObject != undefined) {
+      if (demoteObject.adminApprovalId != loggedInUser.identityUserId) {
+        demoteProfile(userId).then(() => {
+          getUserProfiles();
+          deleteDemote(demoteObject);
+          getAllDemotes().then(setAllDemotes);
+        });
+      }
+    } else {
+      postNewDemote({
+        AdminToDemoteId: userId,
+        AdminApprovalId: loggedInUser.identityUserId,
+      }).then(() => {
+        getAllDemotes().then(setAllDemotes);
+      });
+    }
+  };
+
+  const handleDeactivate = (event) => {
+    if (window.confirm(`Confirm deactivation of: ${event.target.name}`)) {
       deactivateUser(event.target.value)
-        .then(() =>
-        {
+        .then(() => {
           return Promise.all([getUserProfiles(), getDeactivatedUsers()]);
         })
-        .catch(error =>
-        {
-          if(error)
-          {
+        .catch((error) => {
+          if (error) {
             window.alert(`Error: ${error}`);
           }
         });
     }
   };
 
-  const handleReactivate = (event) =>
-  {
-    if(window.confirm(`Confirm Reactivation of: ${event.target.name}`))
-    {
-      reactivateUser(event.target.value).then(() =>
-      {
+  const handleReactivate = (event) => {
+    if (window.confirm(`Confirm Reactivation of: ${event.target.name}`)) {
+      reactivateUser(event.target.value).then(() => {
         getUserProfiles();
         getDeactivatedUsers();
       });
     }
   };
 
-  const handleFilterChange = (event) =>
-  {
-
-    if(event.target.checked)
-    {
+  const handleFilterChange = (event) => {
+    if (event.target.checked) {
       setUserProfiles(deactivatedProfiles);
-    }
-    else
-    {
+    } else {
       getUserProfiles();
     }
   };
-
 
   return (
     <>
@@ -128,30 +130,31 @@ export default function UserProfileList()
       {userprofiles.map((p) => (
         <div key={p.id}>
           <p>
-            {p.firstName} {p.lastName} {p.userName} {p.roles.includes("Admin") ? "admin" : "author"}
+            {p.firstName} {p.lastName} {p.userName}{" "}
+            {p.roles.includes("Admin") ? "admin" : "author"}
             <Link to={`/userprofiles/${p.id}`}>Details</Link>
-            {
-              p.roles.includes("Admin")
-                ? <button onClick={() => demoteClicked(p.identityUserId)}>Demote</button>
-                : <button onClick={() => promoteClicked(p.identityUserId)}>Promote</button>
-            }
-          </p>
-          {
-            !p.isDeactivated && !p.roles.includes("Admin") && (
-              <button name={p.userName} value={p.id} onClick={handleDeactivate}>
-                Deactivate
+            {p.roles.includes("Admin") ? (
+              <button onClick={() => demoteClicked(p.identityUserId)}>
+                Demote
               </button>
-            )
-          }
+            ) : (
+              <button onClick={() => promoteClicked(p.identityUserId)}>
+                Promote
+              </button>
+            )}
+          </p>
+          {!p.isDeactivated && !p.roles.includes("Admin") && (
+            <button name={p.userName} value={p.id} onClick={handleDeactivate}>
+              Deactivate
+            </button>
+          )}
           {p.isDeactivated && !p.roles.includes("Admin") && (
             <button name={p.userName} value={p.id} onClick={handleReactivate}>
               Reactivate
             </button>
           )}
-
-        </div >
-      ))
-      }
+        </div>
+      ))}
     </>
   );
 }

--- a/client/src/managers/admin.js
+++ b/client/src/managers/admin.js
@@ -1,0 +1,17 @@
+const _apiUrl = "/api/admin";
+
+export const getAllDemotes = () => {
+  return fetch(_apiUrl).then((res) => res.json());
+};
+
+export const postNewDemote = (newDemote) => {
+  return fetch(_apiUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(newDemote),
+  });
+};
+
+export const deleteDemote = (deleteDemote) => {
+  return fetch(`${_apiUrl}/${deleteDemote.id}`, { method: "DELETE" });
+};


### PR DESCRIPTION
Purpose: users are now forced to require 2 different admins in order to demote someone(Depromote) 

files changes:
client/src/components/ApplicationViews.jsx
client/src/components/userprofiles/UserProfilesList.jsx
client/src/managers/admin.js
Controllers/AdminController.cs
Models/DTOs/DemoteAdminDTO.cs
Models/DemoteAdmin.cs
TabloidDbContext.cs


To Test; As 1 Admin, Demote a currently existing admin, Then proceed to be a different admin and demote the same Admin.

"You might have to nuke your database"
Closes: #2 